### PR TITLE
fix account_without_digit method

### DIFF
--- a/lib/banktools-br/banks/account.rb
+++ b/lib/banktools-br/banks/account.rb
@@ -21,7 +21,7 @@ module BanktoolsBR
       def normalize
         account_number = sanitize_numbers(bank_account).rjust(bank_account_length, '0')
 
-        [extract_number_without_digit(account_number, bank_account_length), extract_digit(bank_account)].join('-')
+        [bank_account_without_digit, extract_digit(bank_account)].join('-')
       end
 
       # Validates account number based on their length and verification digit.
@@ -36,7 +36,7 @@ module BanktoolsBR
       #
       # @return [String]
       def bank_account_without_digit
-        extract_number_without_digit(bank_account, bank_account_length)
+        extract_number_without_digit(bank_account)
       end
 
       # Full account number (bank_agency + bank_account_without_digit)

--- a/lib/banktools-br/banks/utilities.rb
+++ b/lib/banktools-br/banks/utilities.rb
@@ -20,10 +20,9 @@ module BanktoolsBR
       # Extracts only the number without digit.
       #
       # @param [String] full number with digit
-      # @param [Integer] maximum size of full number
       # @return [String] number without digit
-      def extract_number_without_digit(full_number, maximum_size)
-        sanitize_numbers(full_number).slice(0, maximum_size - 1)
+      def extract_number_without_digit(full_number)
+        sanitize_numbers(full_number).chop
       end
     end
   end

--- a/spec/banktools-br/banks/account_spec.rb
+++ b/spec/banktools-br/banks/account_spec.rb
@@ -22,6 +22,7 @@ describe FakeAccount do
       expect(described_class.new('3589', '1671144-6').bank_account_without_digit).to eq('1671144')
       expect(described_class.new('6695', '1945200-P').bank_account_without_digit).to eq('1945200')
       expect(described_class.new('3295', '04401093').bank_account_without_digit).to eq('0440109')
+      expect(described_class.new('4015', '16807-6').bank_account_without_digit).to eq('16807')
     end
   end
 

--- a/spec/banktools-br/banks/utilities_spec.rb
+++ b/spec/banktools-br/banks/utilities_spec.rb
@@ -28,11 +28,12 @@ describe BanktoolsBR::Banks::Utilities do
 
   describe '#extract_number_without_digit' do
     it 'returns the number from account number without digit' do
-      expect(FakeBank.new.extract_number_without_digit('02939-1', 6)).to eq('02939')
-      expect(FakeBank.new.extract_number_without_digit('123452', 6)).to eq('12345')
-      expect(FakeBank.new.extract_number_without_digit('0293-1', 5)).to eq('0293')
-      expect(FakeBank.new.extract_number_without_digit('9877-5', 5)).to eq('9877')
-      expect(FakeBank.new.extract_number_without_digit('4456', 4)).to eq('445')
+      expect(FakeBank.new.extract_number_without_digit('02939-1')).to eq('02939')
+      expect(FakeBank.new.extract_number_without_digit('123452')).to eq('12345')
+      expect(FakeBank.new.extract_number_without_digit('0293-1')).to eq('0293')
+      expect(FakeBank.new.extract_number_without_digit('9877-5')).to eq('9877')
+      expect(FakeBank.new.extract_number_without_digit('4456')).to eq('445')
+      expect(FakeBank.new.extract_number_without_digit('16807-6')).to eq('16807')
     end
   end
 end


### PR DESCRIPTION
Before this PR, you need to pass the bank account length to the extract_number_without_digit method. 

The problem was that when the account number was not complete, e.g: 16807-6 as a Banco do Brasil account (which needs 9 digits) the `slice` didn't cut the verification digit. 

This PR fix it.